### PR TITLE
Added entry for libusb on mac

### DIFF
--- a/libusb-ffi.lisp
+++ b/libusb-ffi.lisp
@@ -3,6 +3,7 @@
 (in-package #:libusb-ffi)
 
 (define-foreign-library libusb
+  (:bsd "libusb-legacy-0.1.4.4.4.dylib")
   (:unix (:or "libusb-0.1.so.4.4" "libusb-0.1.so.4" "libusb-0.1.so"))
   (:windows "libusb0")
   (t (:default "libusb")))


### PR DESCRIPTION
Unfortunately, I know of no way to determine at runtime exactly WHERE the library lives. But if we copy it into the working directory it should work.

FYI, the mac version of libusb is also missing some functions, such as `usb_get_driver_np`. Ideally, we'd add some kind of platform test and omit those functions.